### PR TITLE
revise workload identity section

### DIFF
--- a/draft-ietf-wimse-s2s-protocol.md
+++ b/draft-ietf-wimse-s2s-protocol.md
@@ -149,9 +149,15 @@ This document uses "service" and "workload" interchangeably. Otherwise, all term
 
 # Workload Identity {#whimsical-identity}
 
-This document defines a workload identity as a URI {{!RFC3986}}. This URI is used in the subject fields in the certificates and tokens defined later in this document. This specification treats the URI as opaque. The format of the URI and the namespace for the URI are at the discretion of the deployment at large. Other specifications may define specific URI structures for particular use cases. An example of a defined identity format is the [SPIFFE ID](https://github.com/spiffe/spiffe/blob/main/standards/SPIFFE-ID.md).
+## Workload Identifier
 
-A workload identity only has meaning within the scope of a specific issuer. Two identities of the same value issued by different issuers may or may not refer to the same workload. In order to avoid collisions identity URIs SHOULD specify, in the URI's "authority" field, the trust domain associated with an issuer that is selected from a global name space such as host domains. However, the validator of an identity credential MUST make sure that they are using the correct issuer credential to verify the identity credential and that the issuer is trusted to issue tokens for the defined trust domain.
+This document defines a workload identifier as a URI {{!RFC3986}}. This URI is used in the subject fields in the certificates and tokens defined later in this document. The URI MUST meet the criteria for the URI type of Subject Alternative Name defined in Section 4.2.1.6 of {{!RFC5280}}.
+
+>   The name MUST NOT be a relative URI, and it MUST follow the URI syntax and
+>   encoding rules specified in {{!RFC3986}}.  The name MUST include both a
+>   scheme and a scheme-specific-part.
+
+In addition the URI MUST include an authority that identifies the trust domain defining the identifier. The trust domain SHOULD be a fully qualified domain name belonging to the organization defining the trust domain to help provide uniqueness for the trust domain identifier. The scheme and scheme specific part are not defined by this specification. An example of an identifier format that conforms to this definition is [SPIFFE ID](https://github.com/spiffe/spiffe/blob/main/standards/SPIFFE-ID.md).
 
 # Application Level Service To Service Authentication {#app-level}
 


### PR DESCRIPTION
Revised the workload identity section to align with RFC 5280 and include trust domain.  Aligns closely with SPIFFE, but allows other schemes to be defined.  