### PR TITLE
Add Option 3 WIT with Authentication Based on the Transport-layer

### DIFF
--- a/draft-ietf-wimse-s2s-protocol.md
+++ b/draft-ietf-wimse-s2s-protocol.md
@@ -176,13 +176,13 @@ While the URI encoding rules allow host names to be specified as IP addresses, I
 
 As noted in the Introduction, for many deployments communication between workloads cannot use
 end-to-end TLS. For these deployment styles, this document proposes application-level protections.
-For deployments using end-to-end TLS, application-level credentials may be used to enrich the 
+For deployments using end-to-end TLS, application-level credentials may be used to enrich the
 application security context.
 
 The current version of the document includes three alternatives, all using the newly introduced
 Workload Identity Token ({{to-wit}}). The first alternative ({{dpop-esque-auth}}) is inspired by the OAuth DPoP specification.
 The second alternative ({{http-sig-auth}}) is based on the HTTP Message Signatures RFC. The third
-alternative ({{transport-layer-pop}}) is based on the TLS 1.3 and Token Binding RFCs. 
+alternative ({{transport-layer-pop}}) is based on the TLS 1.3 and Token Binding RFCs.
 We present the alternatives and expect
 the working group to select those that should progress towards IETF consensus.
 A comparison of the first two alternatives is attempted in {{app-level-comparison}}.

--- a/draft-ietf-wimse-s2s-protocol.md
+++ b/draft-ietf-wimse-s2s-protocol.md
@@ -680,6 +680,6 @@ the Message Signature-based alternative.
 
 <cref>TODO acknowledge.</cref>
 
-## Contributors
+Contributors
 
 * Ken McCracken, Google, kenmccracken@google.com

--- a/draft-ietf-wimse-s2s-protocol.md
+++ b/draft-ietf-wimse-s2s-protocol.md
@@ -43,6 +43,10 @@ author:
     fullname: "Yaron Sheffer"
     organization: Intuit
     email: "yaronf.ietf@gmail.com"
+ -
+    fullname: "Ken McCracken"
+    organization: Google
+    email: "kenmccracken@google.com"
 
 normative:
   RFC5234:
@@ -515,7 +519,7 @@ A signed response would be:
 
 This option provides authentication of the WIT using Transport Layer credentials. The proof-of-possession for the Workload's Private Key is provided in the WIT via a cyrptographically strong hash that MUST match the Transport Layer mutual authentication credential. The cryptographically strong hash binds the WIT to a particular Transport Layer certificate credential, so that it cannot be replayed without proof of the corresponding Workload Private Key.
 
-To authenticate a WIT using the Transport Layer, Workload-to-Workload communication MUST be secured by Mutually-authenticated [Transport Layer Security 1.3](https://datatracker.ietf.org/doc/html/rfc8446#section-2) (TLS 1.3). Proof-of-possession MUST be conveyed via each Workload's `CertificateVerify` message. In this case, each network peer MUST validate its Peer's Proof-of-possession of the Private Key. Proof-of-possession is conveyed during the TLS 1.3 handshake protocol using each peer's `Certificate` and `CertificateVerify` messages. The Transport Layer MUST cache the SHA-256 hash of the validated Client Certificate in the TLS session, for use at the Application Layer. When the Destination Workload receives a WIT at the Application Layer with `cnf` claim with `x5t#S256` property, it MUST establish Proof-of-possession as follows:
+When an Application receives a Certificate-bound WIT, it MUST treat the WIT as a JWT bound to an X.509 certificate in the manner described in [Section 3.1](https://datatracker.ietf.org/doc/html/rfc8705#section-3.1) of [[RFC8705](https://datatracker.ietf.org/doc/html/rfc8705)]. To authenticate a Certificate-bound WIT using the Transport Layer, Workload-to-Workload communication MUST be secured by Mutually-authenticated [Transport Layer Security 1.3](https://datatracker.ietf.org/doc/html/rfc8446#section-2) (TLS 1.3). Proof-of-possession MUST be conveyed via each Workload's `CertificateVerify` message. In this case, each network peer MUST validate its Peer's Proof-of-possession of the Private Key. Proof-of-possession is conveyed during the TLS 1.3 handshake protocol using each peer's `Certificate` and `CertificateVerify` messages. The Transport Layer MUST cache the SHA-256 hash of the validated Client Certificate in the TLS session, for use at the Application Layer. When the Destination Workload receives a WIT at the Application Layer with `cnf` claim with `x5t#S256` property, it MUST establish Proof-of-possession as follows:
 
 * Validate that the Certificate-bound WIT's `cnf` claim's `x5t#S256` property matches the cached SHA-256 hash of the validated Client Certificate used at the Transport layer.
 

--- a/draft-ietf-wimse-s2s-protocol.md
+++ b/draft-ietf-wimse-s2s-protocol.md
@@ -43,10 +43,6 @@ author:
     fullname: "Yaron Sheffer"
     organization: Intuit
     email: "yaronf.ietf@gmail.com"
- -
-    fullname: "Ken McCracken"
-    organization: Google
-    email: "kenmccracken@google.com"
 
 normative:
   RFC5234:
@@ -683,3 +679,7 @@ the Message Signature-based alternative.
 {:numbered="false"}
 
 <cref>TODO acknowledge.</cref>
+
+Contributors
+
+* Ken McCracken, Google, kenmccracken@google.com

--- a/draft-ietf-wimse-s2s-protocol.md
+++ b/draft-ietf-wimse-s2s-protocol.md
@@ -680,6 +680,6 @@ the Message Signature-based alternative.
 
 <cref>TODO acknowledge.</cref>
 
-Contributors
+## Contributors
 
 * Ken McCracken, Google, kenmccracken@google.com


### PR DESCRIPTION
In this approach, the WIT refers to the mTLS X.509 Certificate credential for establishing Workload Authentication.
Resolves #75