### PR TITLE
remove humor

### DIFF
--- a/draft-ietf-wimse-s2s-protocol.md
+++ b/draft-ietf-wimse-s2s-protocol.md
@@ -285,7 +285,7 @@ The Identity Server's public key from this example is shown below in JWK {{RFC75
 
 A WIT is conveyed in an HTTP header field named `Workload-Identity-Token`.
 
-For those who celebrate, ABNF {{RFC5234}} for the value of `Workload-Identity-Token` header field is provided in {{wit-header-abnf}}:
+ABNF {{RFC5234}} for the value of `Workload-Identity-Token` header field is provided in {{wit-header-abnf}}:
 
 ~~~ abnf
 ALPHA = %x41-5A / %x61-7A ; A-Z / a-z


### PR DESCRIPTION
remove "For those who celebrate" to avoid future push-back and b/c the context is more of a stretch here than where the text was first used