### PR TITLE
Clarify response signing section

### DIFF
--- a/draft-ietf-wimse-http-signature.md
+++ b/draft-ietf-wimse-http-signature.md
@@ -143,9 +143,17 @@ may be exceptionally large or is expected to be streamed, signing it may not be 
 
 In practice, we expect response signing to be enabled by local policy. If response signing is enabled for a deployment,
 the client (recipient of the response) MUST check that the signature exists and validate it.
-The response MUST be rejected if a signature is absent or does not validate.
+The response MUST be rejected if a signature is absent or fails to validate.
 
-As described in {{Section 5 of RFC9421}}, either client or server MAY send an `Accept-Signature` header, but is not required to do so. The `Accept-Signature` header indicates a preference for signed messages but does not mandate that responses be signed. When a client sends `Accept-Signature` in a request, it SHOULD list the response components it wishes to have signed (as specified above for signed responses). When a server sends `Accept-Signature` in a response, it SHOULD list the request components it wishes to have signed in subsequent requests (as specified above for signed requests).
+As described in {{Section 5 of RFC9421}}, either client or server MAY send an
+`Accept-Signature` header,
+but is not required to do so. The `Accept-Signature` header indicates a
+preference for signed messages but does not mandate that responses be signed.
+When a client sends `Accept-Signature` in a request, it SHOULD list the
+response components it wishes to have signed (including at least those specified above for signed
+responses). When a server sends `Accept-Signature` in a response, it SHOULD
+list the request components it wishes to have signed in subsequent requests (minimally those
+specified above for signed requests).
 
 ## Error Conditions
 

--- a/draft-ietf-wimse-http-signature.md
+++ b/draft-ietf-wimse-http-signature.md
@@ -135,7 +135,17 @@ a recipient SHOULD reject a message (request or response) if a nonce generated b
 
 Implementors need to be aware that the WIT is extracted from the message before the message signature is validated. Recipients of signed HTTP messages MUST validate the signature and content of the WIT before validating the HTTP message signature. They MUST ensure that the message is not processed further before it has been fully validated.
 
-Either client or server MAY send an `Accept-Signature` header, but is not required to do so. When this header is sent, it MUST include the header components listed above.
+
+## Signing the Response
+
+Protecting the response by signing it with the server's WIT is RECOMMENDED but optional. In particular, if the response
+may be exceptionally large or is expected to be streamed, signing it may not be practical.
+
+In practice, we expect response signing to be enabled by local policy. If response signing is enabled for a deployment,
+the client (recipient of the response) MUST check that the signature exists and validate it.
+The response MUST be rejected if a signature is absent or does not validate.
+
+Either client or server MAY send an `Accept-Signature` header, but is not required to do so. The `Accept-Signature` header indicates a preference for signed messages but does not mandate that responses be signed. When a client sends `Accept-Signature` in a request, it SHOULD list the response components it wishes to have signed (as specified above for signed responses). When a server sends `Accept-Signature` in a response, it SHOULD list the request components it wishes to have signed in subsequent requests (as specified above for signed requests).
 
 ## Error Conditions
 

--- a/draft-ietf-wimse-http-signature.md
+++ b/draft-ietf-wimse-http-signature.md
@@ -145,7 +145,7 @@ In practice, we expect response signing to be enabled by local policy. If respon
 the client (recipient of the response) MUST check that the signature exists and validate it.
 The response MUST be rejected if a signature is absent or does not validate.
 
-Either client or server MAY send an `Accept-Signature` header, but is not required to do so. The `Accept-Signature` header indicates a preference for signed messages but does not mandate that responses be signed. When a client sends `Accept-Signature` in a request, it SHOULD list the response components it wishes to have signed (as specified above for signed responses). When a server sends `Accept-Signature` in a response, it SHOULD list the request components it wishes to have signed in subsequent requests (as specified above for signed requests).
+As described in {{Section 5 of RFC9421}}, either client or server MAY send an `Accept-Signature` header, but is not required to do so. The `Accept-Signature` header indicates a preference for signed messages but does not mandate that responses be signed. When a client sends `Accept-Signature` in a request, it SHOULD list the response components it wishes to have signed (as specified above for signed responses). When a server sends `Accept-Signature` in a response, it SHOULD list the request components it wishes to have signed in subsequent requests (as specified above for signed requests).
 
 ## Error Conditions
 


### PR DESCRIPTION
- Clarify that Accept-Signature is a preference, not a mandate
- Specify which components to include in Accept-Signature header
- Clarify that client (recipient of response) must validate signatures
- Add requirement to reject responses if signature is absent or invalid

Closes #188.