### PR TITLE
Fix README links for all active drafts (#218)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ report.xml
 !requirements.txt
 spellcheck.sh
 *.pws
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,12 +1,34 @@
 # WIMSE Workload-to-Workload Authentication
 
-This is the working area for the IETF [WIMSE Working Group](https://datatracker.ietf.org/wg/wimse/documents/) Internet-Draft, "WIMSE Workload-to-Workload Authentication".
+This is the working area for the IETF [WIMSE Working Group](https://datatracker.ietf.org/wg/wimse/documents/) documents on workload identity and workload-to-workload authentication. The repository builds several related Internet-Drafts.
 
-* [Editor's Copy](https://ietf-wg-wimse.github.io/draft-ietf-wimse-s2s-protocol/#go.draft-ietf-wimse-s2s-protocol.html)
-* [Datatracker Page](https://datatracker.ietf.org/doc/draft-ietf-wimse-s2s-protocol)
-* [Working Group Draft](https://datatracker.ietf.org/doc/html/draft-ietf-wimse-s2s-protocol)
-* [Compare Editor's Copy to Working Group Draft](https://ietf-wg-wimse.github.io/draft-ietf-wimse-s2s-protocol/#go.draft-ietf-wimse-s2s-protocol.diff)
+## WIMSE Workload Credentials
 
+* [Editor's Copy](https://ietf-wg-wimse.github.io/draft-ietf-wimse-s2s-protocol/#go.draft-ietf-wimse-workload-creds.html)
+* [Datatracker Page](https://datatracker.ietf.org/doc/draft-ietf-wimse-workload-creds)
+* [Working Group Draft](https://datatracker.ietf.org/doc/html/draft-ietf-wimse-workload-creds)
+* [Compare Editor's Copy to Working Group Draft](https://ietf-wg-wimse.github.io/draft-ietf-wimse-s2s-protocol/#go.draft-ietf-wimse-workload-creds.diff)
+
+## WIMSE Workload Proof Token
+
+* [Editor's Copy](https://ietf-wg-wimse.github.io/draft-ietf-wimse-s2s-protocol/#go.draft-ietf-wimse-wpt.html)
+* [Datatracker Page](https://datatracker.ietf.org/doc/draft-ietf-wimse-wpt)
+* [Working Group Draft](https://datatracker.ietf.org/doc/html/draft-ietf-wimse-wpt)
+* [Compare Editor's Copy to Working Group Draft](https://ietf-wg-wimse.github.io/draft-ietf-wimse-s2s-protocol/#go.draft-ietf-wimse-wpt.diff)
+
+## WIMSE Workload-to-Workload Authentication with HTTP Signatures
+
+* [Editor's Copy](https://ietf-wg-wimse.github.io/draft-ietf-wimse-s2s-protocol/#go.draft-ietf-wimse-http-signature.html)
+* [Datatracker Page](https://datatracker.ietf.org/doc/draft-ietf-wimse-http-signature)
+* [Working Group Draft](https://datatracker.ietf.org/doc/html/draft-ietf-wimse-http-signature)
+* [Compare Editor's Copy to Working Group Draft](https://ietf-wg-wimse.github.io/draft-ietf-wimse-s2s-protocol/#go.draft-ietf-wimse-http-signature.diff)
+
+## Workload Authentication Using Mutual TLS
+
+* [Editor's Copy](https://ietf-wg-wimse.github.io/draft-ietf-wimse-s2s-protocol/#go.draft-ietf-wimse-mutual-tls.html)
+* [Datatracker Page](https://datatracker.ietf.org/doc/draft-ietf-wimse-mutual-tls)
+* [Working Group Draft](https://datatracker.ietf.org/doc/html/draft-ietf-wimse-mutual-tls)
+* [Compare Editor's Copy to Working Group Draft](https://ietf-wg-wimse.github.io/draft-ietf-wimse-s2s-protocol/#go.draft-ietf-wimse-mutual-tls.diff)
 
 ## Contributing
 
@@ -27,4 +49,3 @@ $ make
 
 Command line usage requires that you have the necessary software installed.  See
 [the instructions](https://github.com/martinthomson/i-d-template/blob/main/doc/SETUP.md).
-

--- a/README.md
+++ b/README.md
@@ -32,8 +32,7 @@ This is the working area for the IETF [WIMSE Working Group](https://datatracker.
 
 ## Contributing
 
-See the
-[guidelines for contributions](https://github.com/ietf-wg-wimse/draft-ietf-wimse-s2s-protocol/blob/main/CONTRIBUTING.md).
+See the [guidelines for contributions](https://github.com/ietf-wg-wimse/draft-ietf-wimse-s2s-protocol/blob/main/CONTRIBUTING.md).
 
 Contributions can be made by creating pull requests.
 The GitHub interface supports creating pull requests using the Edit (✏) button.
@@ -41,7 +40,7 @@ The GitHub interface supports creating pull requests using the Edit (✏) button
 
 ## Command Line Usage
 
-Formatted text and HTML versions of the draft can be built using `make`.
+Formatted text and HTML versions of the drafts can be built using `make`.
 
 ```sh
 $ make


### PR DESCRIPTION
## Summary
- Update README to list Editor's Copy, Datatracker, WG HTML, and diff links for each active split draft (workload-creds, wpt, http-signature, mutual-tls).
- Add `.DS_Store` to `.gitignore`.
- Minor README wording (drafts plural, contributing link on one line).

Fixes #218

Made with [Cursor](https://cursor.com)