### PR TITLE
Other fields for AA

### DIFF
--- a/draft-ietf-wimse-workload-creds.md
+++ b/draft-ietf-wimse-workload-creds.md
@@ -371,6 +371,8 @@ How the receiving application obtains the workload identifier depends on the cre
 * Application-level: After successfully validating the WIT, the receiving application retrieves the workload identifier from the `sub` claim.
 * Transport-level: When the client is authenticated with a Workload Identity Certificate, the receiving application retrieves the workload identifier from the client certificate's SubjectAltName extension of type URI.
 
+A workload may use other standard and deployment specific fields in the workload credential for accounting or authorization purposes.
+
 # Implementation Status
 
 <cref>Note to RFC Editor: please remove this section, as well as the reference to RFC 7942, before publication.</cref>

--- a/draft-ietf-wimse-workload-creds.md
+++ b/draft-ietf-wimse-workload-creds.md
@@ -371,7 +371,7 @@ How the receiving application obtains the workload identifier depends on the cre
 * Application-level: After successfully validating the WIT, the receiving application retrieves the workload identifier from the `sub` claim.
 * Transport-level: When the client is authenticated with a Workload Identity Certificate, the receiving application retrieves the workload identifier from the client certificate's SubjectAltName extension of type URI.
 
-A workload may use other standard and deployment specific fields in the workload credential for accounting or authorization purposes.
+A workload MAY use other standard and deployment specific fields in the workload credential for accounting or authorization purposes.
 
 # Implementation Status
 


### PR DESCRIPTION
Note that other fields in the identity credential can be used for authorization and accounting,

issue #162 