### PR TITLE
HTTP target URI audience model and response request binding (#173, #175, #240)

### DIFF
--- a/draft-ietf-wimse-http-signature.md
+++ b/draft-ietf-wimse-http-signature.md
@@ -158,7 +158,7 @@ The default value for `wimse-aud` is the request's HTTP target URI ({{Section 7.
 Senders, recipients, and intermediaries do not always derive the same string for that URI: normalization and rewriting differ by implementation and hop, so the audience that verification should use is a deployment-specific choice.
 When the default string is not suitable for verification at the recipient, senders SHOULD set `wimse-aud` to an explicit audience value as appropriate for that deployment.
 
-The recipient MUST be able to verify that the audience is intended for it, using trusted configuration or a local API (for example, to determine the expected request URI or to validate a received audience value); see "Workload Identifiers and Authentication Granularity" in {{I-D.ietf-wimse-workload-creds}}.
+The recipient MUST be able to verify that the audience refers to it. See "Workload Identifiers and Authentication Granularity" in {{I-D.ietf-wimse-workload-creds}} for more detail.
 
 ## The `wimse-req-nonce` Signature Parameter {#wimse-req-nonce-param}
 

--- a/draft-ietf-wimse-http-signature.md
+++ b/draft-ietf-wimse-http-signature.md
@@ -394,7 +394,7 @@ IANA is requested to register the following entries in the "HTTP Signature Metad
 
 ## draft-ietf-wimse-http-signature-04
 
-* On signed responses, require `wimse-req-nonce` (request binding); register with IANA.
+* On signed responses, require `wimse-req-nonce` (request binding); register with IANA. Non-normative response example not updated accordingly; the `Signature` value was not regenerated (see issue tracker).
 
 ## draft-ietf-wimse-http-signature-03
 

--- a/draft-ietf-wimse-http-signature.md
+++ b/draft-ietf-wimse-http-signature.md
@@ -125,6 +125,10 @@ For requests only, the following signature parameter MUST also be included:
 
 * `wimse-aud` ({{wimse-aud-param}})
 
+For responses only, when response signing is enabled, the following signature parameter MUST also be included:
+
+* `wimse-req-nonce` ({{wimse-req-nonce-param}})
+
 The following signature parameters in the `Signature-Input` header MUST NOT be used:
 
 * `keyid` - The signing key is sent along with the message in the WIT. Additionally specifying the key identity would add confusion.
@@ -154,7 +158,15 @@ The default value for `wimse-aud` is the request's HTTP target URI ({{Section 7.
 Senders, recipients, and intermediaries do not always derive the same string for that URI: normalization and rewriting differ by implementation and hop, so the audience that verification should use is a deployment-specific choice.
 When the default string is not suitable for verification at the recipient, senders SHOULD set `wimse-aud` to an explicit audience value as appropriate for that deployment.
 
-The recipient MUST be able to verify that the audience refers to it. See "Workload Identifiers and Authentication Granularity" in {{I-D.ietf-wimse-workload-creds}} for more detail.
+The recipient MUST be able to verify that the audience is intended for it, using trusted configuration or a local API (for example, to determine the expected request URI or to validate a received audience value); see "Workload Identifiers and Authentication Granularity" in {{I-D.ietf-wimse-workload-creds}}.
+
+## The `wimse-req-nonce` Signature Parameter {#wimse-req-nonce-param}
+
+When response signing is enabled, this document defines the `wimse-req-nonce` signature metadata parameter for responses.
+This parameter binds requests to responses and prevents a malicious
+proxy from replaying responses to the wrong client.
+
+The server MUST set `wimse-req-nonce` to the value of the `nonce` signature parameter from the `Signature-Input` of the request that triggered the response.
 
 ## Signing the Response
 
@@ -164,6 +176,8 @@ may be exceptionally large or is expected to be streamed, signing it may not be 
 In practice, we expect response signing to be enabled by local policy. If response signing is enabled for a deployment,
 the client (recipient of the response) MUST check that the signature exists and validate it.
 The response MUST be rejected if a signature is absent or fails to validate.
+The client MUST verify that `wimse-req-nonce` matches the `nonce` it included in its request's `Signature-Input`.
+This binds the signed response to the specific request that triggered it.
 
 As described in {{Section 5 of RFC9421}}, either client or server MAY send an
 `Accept-Signature` header,
@@ -333,7 +347,7 @@ been activated and likewise, the recipient validates this signature.
 * No requests can be modified without detection by the recipient. Integrity of
   all present HTTP headers specified in this document is protected, as well as
 the derived components listed in {{http-sig-auth}}, the signature parameters
-(including `wimse-aud` on requests) as covered by `@signature-params` in {{RFC9421}}, and
+(including `wimse-aud` on requests and `wimse-req-nonce` on responses) as covered by `@signature-params` in {{RFC9421}}, and
 the message body (when present).
 * No responses can be modified without detection, provided that optional response signing has been activated and
 that the recipient validates incoming responses.
@@ -348,6 +362,7 @@ caches across validators). Therefore it is not claimed as
 a goal, though implementations SHOULD attempt to detect replays where feasible.
 We note that since most of the message is signed, replay attacks are only possible in a
 context where the request would be accepted as valid, and this mitigates the risk to some extent.
+* When response signing is enabled, validating `wimse-req-nonce` mitigates replay of a signed response to a client other than the one that sent the triggering request.
 * Unless response signing is mandated by local policy, complete deletion of a request/response pair is possible without detection.
 
 
@@ -355,9 +370,10 @@ context where the request would be accepted as valid, and this mitigates the ris
 
 ## HTTP Signature Metadata Parameters Registration
 
-IANA is requested to register the following entry in the "HTTP Signature Metadata Parameters" registry {{IANA.HTTP.MESSAGE.SIGNATURE}}, per the registration template in Section 6.3.1 of {{RFC9421}}:
+IANA is requested to register the following entries in the "HTTP Signature Metadata Parameters" registry {{IANA.HTTP.MESSAGE.SIGNATURE}}, per the registration template in Section 6.3.1 of {{RFC9421}}:
 
 * `wimse-aud`, per {{iana-wimse-aud-param}}.
+* `wimse-req-nonce`, per {{iana-wimse-req-nonce-param}}.
 
 ### `wimse-aud` {#iana-wimse-aud-param}
 
@@ -365,10 +381,20 @@ IANA is requested to register the following entry in the "HTTP Signature Metadat
 * Description: the WIMSE message audience. Request signatures only; binds the HTTP message signature to the intended recipient.
 * Reference: RFC XXX, {{wimse-aud-param}}.
 
+### `wimse-req-nonce` {#iana-wimse-req-nonce-param}
+
+* Name: `wimse-req-nonce`
+* Description: on response signatures, the `nonce` value from the triggering request's `Signature-Input`; binds the response to that request.
+* Reference: RFC XXX, {{wimse-req-nonce-param}}.
+
 --- back
 
 # Document History
 <cref>RFC Editor: please remove before publication.</cref>
+
+## draft-ietf-wimse-http-signature-04
+
+* On signed responses, require `wimse-req-nonce` (request binding); register with IANA.
 
 ## draft-ietf-wimse-http-signature-03
 

--- a/draft-ietf-wimse-http-signature.md
+++ b/draft-ietf-wimse-http-signature.md
@@ -158,7 +158,7 @@ The default value for `wimse-aud` is the request's HTTP target URI ({{Section 7.
 Senders, recipients, and intermediaries do not always derive the same string for that URI: normalization and rewriting differ by implementation and hop, so the audience that verification should use is a deployment-specific choice.
 When the default string is not suitable for verification at the recipient, senders SHOULD set `wimse-aud` to an explicit audience value as appropriate for that deployment.
 
-The recipient MUST be able to verify that the audience refers to it. See "Workload Identifiers and Authentication Granularity" in {{I-D.ietf-wimse-workload-creds}} for more detail.
+The recipient MUST be able to verify that the audience refers to it. See "Application-Layer Audience" in {{I-D.ietf-wimse-workload-creds}} for more detail.
 
 ## The `wimse-req-nonce` Signature Parameter {#wimse-req-nonce-param}
 

--- a/draft-ietf-wimse-workload-creds.md
+++ b/draft-ietf-wimse-workload-creds.md
@@ -162,7 +162,7 @@ To enable mutual and granular authentication between workloads, two things must 
 - Each workload must know its own identifier.
 - The infrastructure must make available to workloads some means to verify that an HTTP target URI ({{Section 7.1 of RFC9110}}), without query or fragment components, is intended for them.
 
-Once these conditions are met, the methods described in this document can be used for the caller and callee to mutually authenticate. Specifically, deployments should use this capability for consistent audience validation within their environment.
+Once these conditions are met, the methods described in this document can be used for the caller and callee to authenticate. Specifically, deployments should use this capability for consistent audience validation within their environment.
 
 Application-level proof-of-possession mechanisms in {{?I-D.ietf-wimse-wpt}} and {{?I-D.ietf-wimse-http-signature}} use the HTTP target URI ({{Section 7.1 of RFC9110}}) of the request, without query or fragment components, as audience. The Workload Identifier in a WIT or WIC identifies the sender; the audience identifies the intended recipient. The caller sets the audience to the HTTP target URI; the callee verifies that the audience is intended for it using infrastructure support as described above, including any deployment-specific aliases or normalization. For mutual TLS, the caller uses the same support when validating the server by workload identity rather than DNS hostname (see {{?I-D.ietf-wimse-mutual-tls}}).
 

--- a/draft-ietf-wimse-workload-creds.md
+++ b/draft-ietf-wimse-workload-creds.md
@@ -165,8 +165,10 @@ to its workload identifier.
 
 Once these conditions are met, the methods described in this document can be used for the caller and callee to mutually authenticate.
 
-Implementations MUST allow for defining this mapping between the workload's access path and the workload identifier (e.g., through
-callback functions). Deployments SHOULD use these features to establish a consistent set of identifiers within their environment.
+Implementations MUST allow for defining this mapping from the workload's access path to the workload identifier through a concrete API (e.g., callback functions). Deployments SHOULD use these features to establish a consistent set of identifiers within their environment.
+
+Application-level proof-of-possession mechanisms in {{?I-D.ietf-wimse-wpt}} and {{?I-D.ietf-wimse-http-signature}} carry audience as the HTTP target URI of the request (the access handle the caller uses). The Workload Identifier in a WIT or WIC identifies the sender. The Audience identifies the recipient.
+The caller sets the audience to the request URI; the callee validates that the audience is intended for it using the mapping API, including any deployment-specific aliases or normalization. For mutual TLS, the caller uses the same mapping when validating the server by workload identity rather than DNS hostname (see {{?I-D.ietf-wimse-mutual-tls}}).
 
 # Conventions and Definitions
 
@@ -550,6 +552,10 @@ IANA is requested to register the following entries to the "Hypertext Transfer P
 
 # Document History
 <cref>RFC Editor: please remove before publication.</cref>
+
+## draft-ietf-wimse-workload-creds-02
+
+* Clarify access-path-to-identifier mapping direction and concrete API in "Workload Identifiers and Authentication Granularity"; document HTTP URI audience vs Workload Identifier roles.
 
 ## draft-ietf-wimse-workload-creds-01
 

--- a/draft-ietf-wimse-workload-creds.md
+++ b/draft-ietf-wimse-workload-creds.md
@@ -160,15 +160,11 @@ if the server certificate is valid within a trust domain, not if it's tied to a 
 To enable mutual and granular authentication between workloads, two things must be in place:
 
 - Each workload must know its own identifier.
-- There needs to be an explicit mapping from the external handle used to access a workload (such as an Ingress path or service DNS name)
-to its workload identifier.
+- The infrastructure must make available to workloads some means to verify that an HTTP target URI (authority and path) is intended for them.
 
-Once these conditions are met, the methods described in this document can be used for the caller and callee to mutually authenticate.
+Once these conditions are met, the methods described in this document can be used for the caller and callee to mutually authenticate. Specifically, deployments should use this capability for consistent audience validation within their environment.
 
-Implementations MUST allow for defining this mapping from the workload's access path to the workload identifier through a concrete API (e.g., callback functions). Deployments SHOULD use these features to establish a consistent set of identifiers within their environment.
-
-Application-level proof-of-possession mechanisms in {{?I-D.ietf-wimse-wpt}} and {{?I-D.ietf-wimse-http-signature}} carry audience as the HTTP target URI of the request (the access handle the caller uses). The Workload Identifier in a WIT or WIC identifies the sender. The Audience identifies the recipient.
-The caller sets the audience to the request URI; the callee validates that the audience is intended for it using the mapping API, including any deployment-specific aliases or normalization. For mutual TLS, the caller uses the same mapping when validating the server by workload identity rather than DNS hostname (see {{?I-D.ietf-wimse-mutual-tls}}).
+Application-level proof-of-possession mechanisms in {{?I-D.ietf-wimse-wpt}} and {{?I-D.ietf-wimse-http-signature}} use the HTTP target URI of the request as audience. The Workload Identifier in a WIT or WIC identifies the sender; the audience identifies the intended recipient. The caller sets the audience to the HTTP target URI; the callee verifies that the audience is intended for it using infrastructure support as described above, including any deployment-specific aliases or normalization. For mutual TLS, the caller uses the same support when validating the server by workload identity rather than DNS hostname (see {{?I-D.ietf-wimse-mutual-tls}}).
 
 # Conventions and Definitions
 
@@ -555,7 +551,7 @@ IANA is requested to register the following entries to the "Hypertext Transfer P
 
 ## draft-ietf-wimse-workload-creds-02
 
-* Clarify access-path-to-identifier mapping direction and concrete API in "Workload Identifiers and Authentication Granularity"; document HTTP URI audience vs Workload Identifier roles.
+* Clarify that infrastructure must support verifying HTTP target URI against workload; document HTTP URI audience vs Workload Identifier roles.
 
 ## draft-ietf-wimse-workload-creds-01
 

--- a/draft-ietf-wimse-workload-creds.md
+++ b/draft-ietf-wimse-workload-creds.md
@@ -160,11 +160,11 @@ if the server certificate is valid within a trust domain, not if it's tied to a 
 To enable mutual and granular authentication between workloads, two things must be in place:
 
 - Each workload must know its own identifier.
-- The infrastructure must make available to workloads some means to verify that an HTTP target URI (authority and path) is intended for them.
+- The infrastructure must make available to workloads some means to verify that an HTTP target URI ({{Section 7.1 of RFC9110}}), without query or fragment components, is intended for them.
 
 Once these conditions are met, the methods described in this document can be used for the caller and callee to mutually authenticate. Specifically, deployments should use this capability for consistent audience validation within their environment.
 
-Application-level proof-of-possession mechanisms in {{?I-D.ietf-wimse-wpt}} and {{?I-D.ietf-wimse-http-signature}} use the HTTP target URI of the request as audience. The Workload Identifier in a WIT or WIC identifies the sender; the audience identifies the intended recipient. The caller sets the audience to the HTTP target URI; the callee verifies that the audience is intended for it using infrastructure support as described above, including any deployment-specific aliases or normalization. For mutual TLS, the caller uses the same support when validating the server by workload identity rather than DNS hostname (see {{?I-D.ietf-wimse-mutual-tls}}).
+Application-level proof-of-possession mechanisms in {{?I-D.ietf-wimse-wpt}} and {{?I-D.ietf-wimse-http-signature}} use the HTTP target URI ({{Section 7.1 of RFC9110}}) of the request, without query or fragment components, as audience. The Workload Identifier in a WIT or WIC identifies the sender; the audience identifies the intended recipient. The caller sets the audience to the HTTP target URI; the callee verifies that the audience is intended for it using infrastructure support as described above, including any deployment-specific aliases or normalization. For mutual TLS, the caller uses the same support when validating the server by workload identity rather than DNS hostname (see {{?I-D.ietf-wimse-mutual-tls}}).
 
 # Conventions and Definitions
 

--- a/draft-ietf-wimse-workload-creds.md
+++ b/draft-ietf-wimse-workload-creds.md
@@ -160,11 +160,37 @@ if the server certificate is valid within a trust domain, not if it's tied to a 
 To enable mutual and granular authentication between workloads, two things must be in place:
 
 - Each workload must know its own identifier.
-- The infrastructure must make available to workloads some means to verify that an HTTP target URI ({{Section 7.1 of RFC9110}}), without query or fragment components, is intended for them.
+- Each workload must be able to verify that it is the intended recipient of a given request
+  (that is, that it is the intended audience for that request).
 
-Once these conditions are met, the methods described in this document can be used for the caller and callee to authenticate. Specifically, deployments should use this capability for consistent audience validation within their environment.
+Once these conditions are met, the methods described in this document can be used for the caller and callee to authenticate one another.
 
-Application-level proof-of-possession mechanisms in {{?I-D.ietf-wimse-wpt}} and {{?I-D.ietf-wimse-http-signature}} use the HTTP target URI ({{Section 7.1 of RFC9110}}) of the request, without query or fragment components, as audience. The Workload Identifier in a WIT or WIC identifies the sender; the audience identifies the intended recipient. The caller sets the audience to the HTTP target URI; the callee verifies that the audience is intended for it using infrastructure support as described above, including any deployment-specific aliases or normalization. For mutual TLS, the caller uses the same support when validating the server by workload identity rather than DNS hostname (see {{?I-D.ietf-wimse-mutual-tls}}).
+How that recipient check is expressed depends on whether authentication is performed at the application layer or at the transport layer.
+
+### Application-Layer Audience {#app-audience}
+
+Application-level proof-of-possession mechanisms in {{?I-D.ietf-wimse-wpt}} and {{?I-D.ietf-wimse-http-signature}}
+bind a request to an intended recipient using an audience value.
+The Workload Identifier in a WIT identifies the sender; the audience identifies the intended recipient.
+
+By default, the caller sets the audience to the HTTP target URI ({{Section 7.1 of RFC9110}}) of the request,
+without query or fragment components.
+Intermediaries may rewrite that URI in transit, so the callee MUST NOT rely solely on the request URI as
+observed on the wire to decide whether it is the intended recipient.
+Instead, the callee verifies that the audience value carried in the proof is intended for it.
+In some cases this might necessitate infrastructure support to account for deployment-specific aliases or normalization.
+Deployments SHOULD use this capability for consistent audience validation within their environment.
+
+### Transport-Layer Recipient Check {#transport-identity}
+
+At the transport layer there is no separate audience claim analogous to application-layer proof of possession.
+HTTP already requires that, once a server has reconstructed the request's target URI, it decide whether it is
+configured to process that request and whether the connection context is appropriate for it, and an origin server
+MUST reject requests that appear to have been misdirected ({{Section 7.4 of RFC9110}}).
+When connections are reused across origins — as HTTP/2 permits — a server that is not authoritative for a request
+indicates that by responding with 421 (Misdirected Request) ({{Section 9.1.1 of RFC9113}}).
+That check — together with ordinary TLS server authentication (including the rules in {{?I-D.ietf-wimse-mutual-tls}}) —
+is the recipient validation available when relying on mutual TLS alone.
 
 # Conventions and Definitions
 
@@ -551,7 +577,8 @@ IANA is requested to register the following entries to the "Hypertext Transfer P
 
 ## draft-ietf-wimse-workload-creds-02
 
-* Clarify that infrastructure must support verifying HTTP target URI against workload; document HTTP URI audience vs Workload Identifier roles.
+* Separate general recipient/audience requirements from application-layer audience (WPT, HTTP signatures);
+  for transport/mTLS, rely on HTTP rejecting misdirected requests (RFC 9110 Section 7.4) rather than a separate audience claim.
 
 ## draft-ietf-wimse-workload-creds-01
 

--- a/draft-ietf-wimse-workload-creds.md
+++ b/draft-ietf-wimse-workload-creds.md
@@ -166,7 +166,7 @@ To enable mutual and granular authentication between workloads, two things must 
 
 Once these conditions are met, the methods described in this document can be used for the caller and callee to mutually authenticate.
 
-How that recipient check is expressed depends on whether authentication is performed at the application layer or at the transport layer.
+For application-level proof of possession, that recipient check is expressed as follows.
 
 ### Application-Layer Audience {#app-audience}
 
@@ -181,17 +181,6 @@ observed on the wire to decide whether it is the intended recipient.
 Instead, the callee verifies that the audience value carried in the proof is intended for it.
 In some cases this might necessitate infrastructure support to account for deployment-specific aliases or normalization.
 Deployments SHOULD use this capability for consistent audience validation within their environment.
-
-### Transport-Layer Recipient Check {#transport-identity}
-
-At the transport layer there is no separate audience claim analogous to application-layer proof of possession.
-HTTP already requires that, once a server has reconstructed the request's target URI, it decide whether it is
-configured to process that request and whether the connection context is appropriate for it, and an origin server
-MUST reject requests that appear to have been misdirected ({{Section 7.4 of RFC9110}}).
-When connections are reused across origins — as HTTP/2 permits — a server that is not authoritative for a request
-indicates that by responding with 421 (Misdirected Request) ({{Section 9.1.1 of ?RFC9113}}).
-That check — together with ordinary TLS server authentication (including the rules in {{?I-D.ietf-wimse-mutual-tls}}) —
-is the recipient validation available when relying on mutual TLS alone.
 
 # Conventions and Definitions
 
@@ -599,8 +588,7 @@ IANA is requested to register the following entries to the "Hypertext Transfer P
 
 ## draft-ietf-wimse-workload-creds-04
 
-* Separate general recipient/audience requirements from application-layer audience (WPT, HTTP signatures);
-  for transport/mTLS, rely on HTTP rejecting misdirected requests (RFC 9110 Section 7.4) rather than a separate audience claim (#173, #175).
+* Replace the access-path-to-identifier mapping API with application-layer audience for WPT and HTTP signatures (#173, #175).
 
 ## draft-ietf-wimse-workload-creds-03
 

--- a/draft-ietf-wimse-workload-creds.md
+++ b/draft-ietf-wimse-workload-creds.md
@@ -172,15 +172,15 @@ For application-level proof of possession, that recipient check is expressed as 
 
 Application-level proof-of-possession mechanisms in {{?I-D.ietf-wimse-wpt}} and {{?I-D.ietf-wimse-http-signature}}
 bind a request to an intended recipient using an audience value.
-The Workload Identifier in a WIT identifies the sender; the audience identifies the intended recipient.
+The Workload Identifier in a WIT identifies the sender; the audience of the PoP identifies the intended recipient.
 
 By default, the caller sets the audience to the HTTP target URI ({{Section 7.1 of RFC9110}}) of the request,
 without query or fragment components.
-Intermediaries may rewrite that URI in transit, so the callee MUST NOT rely solely on the request URI as
+Intermediaries may rewrite the URI of the request in transit, so the callee MUST NOT rely solely on the request URI as
 observed on the wire to decide whether it is the intended recipient.
-Instead, the callee verifies that the audience value carried in the proof is intended for it.
-In some cases this might necessitate infrastructure support to account for deployment-specific aliases or normalization.
-Deployments SHOULD use this capability for consistent audience validation within their environment.
+The callee MUST verify that the audience value carried in the proof is intended for it.
+Deployments MUST provide the configuration or infrastructure needed for that verification,
+including support for deployment-specific aliases or normalization where request URIs may be rewritten in transit.
 
 # Conventions and Definitions
 

--- a/draft-ietf-wimse-workload-creds.md
+++ b/draft-ietf-wimse-workload-creds.md
@@ -161,13 +161,37 @@ but not that it belongs to the particular workload the client intended to reach.
 To enable mutual and granular authentication between workloads, two things must be in place:
 
 - Each workload must know its own identifier.
-- There needs to be an explicit mapping from the external access name used to access a workload (such as an Ingress path or service DNS name)
-to its Workload Identifier.
+- Each workload must be able to verify that it is the intended recipient of a given request
+  (that is, that it is the intended audience for that request).
 
 Once these conditions are met, the methods described in this document can be used for the caller and callee to mutually authenticate.
 
-Implementations MUST allow for defining this mapping between the workload's external access name and the Workload Identifier (e.g., through
-callback functions). Deployments SHOULD use these features to establish a consistent set of identifiers within their environment.
+How that recipient check is expressed depends on whether authentication is performed at the application layer or at the transport layer.
+
+### Application-Layer Audience {#app-audience}
+
+Application-level proof-of-possession mechanisms in {{?I-D.ietf-wimse-wpt}} and {{?I-D.ietf-wimse-http-signature}}
+bind a request to an intended recipient using an audience value.
+The Workload Identifier in a WIT identifies the sender; the audience identifies the intended recipient.
+
+By default, the caller sets the audience to the HTTP target URI ({{Section 7.1 of RFC9110}}) of the request,
+without query or fragment components.
+Intermediaries may rewrite that URI in transit, so the callee MUST NOT rely solely on the request URI as
+observed on the wire to decide whether it is the intended recipient.
+Instead, the callee verifies that the audience value carried in the proof is intended for it.
+In some cases this might necessitate infrastructure support to account for deployment-specific aliases or normalization.
+Deployments SHOULD use this capability for consistent audience validation within their environment.
+
+### Transport-Layer Recipient Check {#transport-identity}
+
+At the transport layer there is no separate audience claim analogous to application-layer proof of possession.
+HTTP already requires that, once a server has reconstructed the request's target URI, it decide whether it is
+configured to process that request and whether the connection context is appropriate for it, and an origin server
+MUST reject requests that appear to have been misdirected ({{Section 7.4 of RFC9110}}).
+When connections are reused across origins — as HTTP/2 permits — a server that is not authoritative for a request
+indicates that by responding with 421 (Misdirected Request) ({{Section 9.1.1 of ?RFC9113}}).
+That check — together with ordinary TLS server authentication (including the rules in {{?I-D.ietf-wimse-mutual-tls}}) —
+is the recipient validation available when relying on mutual TLS alone.
 
 # Conventions and Definitions
 
@@ -572,6 +596,11 @@ IANA is requested to register the following entries to the "Hypertext Transfer P
 
 # Document History
 <cref>RFC Editor: please remove before publication.</cref>
+
+## draft-ietf-wimse-workload-creds-04
+
+* Separate general recipient/audience requirements from application-layer audience (WPT, HTTP signatures);
+  for transport/mTLS, rely on HTTP rejecting misdirected requests (RFC 9110 Section 7.4) rather than a separate audience claim (#173, #175).
 
 ## draft-ietf-wimse-workload-creds-03
 

--- a/draft-ietf-wimse-workload-creds.md
+++ b/draft-ietf-wimse-workload-creds.md
@@ -59,6 +59,7 @@ informative:
   IANA.JOSE.ALGS: IANA.jose_web-signature-encryption-algorithms
   IANA.JWT.CLAIMS: IANA.jwt_claims
   IANA.MEDIA.TYPES: IANA.media-types
+  RFC9113:
   RFC9457:
 
 --- abstract

--- a/draft-ietf-wimse-workload-creds.md
+++ b/draft-ietf-wimse-workload-creds.md
@@ -59,7 +59,6 @@ informative:
   IANA.JOSE.ALGS: IANA.jose_web-signature-encryption-algorithms
   IANA.JWT.CLAIMS: IANA.jwt_claims
   IANA.MEDIA.TYPES: IANA.media-types
-  RFC9113:
   RFC9457:
 
 --- abstract
@@ -189,7 +188,7 @@ HTTP already requires that, once a server has reconstructed the request's target
 configured to process that request and whether the connection context is appropriate for it, and an origin server
 MUST reject requests that appear to have been misdirected ({{Section 7.4 of RFC9110}}).
 When connections are reused across origins — as HTTP/2 permits — a server that is not authoritative for a request
-indicates that by responding with 421 (Misdirected Request) ({{Section 9.1.1 of RFC9113}}).
+indicates that by responding with 421 (Misdirected Request) ({{Section 9.1.1 of ?RFC9113}}).
 That check — together with ordinary TLS server authentication (including the rules in {{?I-D.ietf-wimse-mutual-tls}}) —
 is the recipient validation available when relying on mutual TLS alone.
 

--- a/draft-ietf-wimse-wpt.md
+++ b/draft-ietf-wimse-wpt.md
@@ -97,9 +97,9 @@ A WPT MUST contain the following:
      using the `application/wpt+jwt` media type.
 * in the JWT claims:
     * `aud`: The audience SHOULD contain the HTTP target URI ({{Section 7.1 of RFC9110}}) of the request
-     to which the WPT is attached, without query or fragment parts. Senders set the audience to the URI they use for the request.
-     However, normalization, rewriting, or other deployment-specific processing may require a different audience value.
-     Recipients validate that the audience is intended for them, using trusted configuration or a local API (for example, to determine the expected request URI or to validate a received audience value); see "Workload Identifiers and Authentication Granularity" in {{!I-D.ietf-wimse-workload-creds}}.
+     to which the WPT is attached, without query or fragment parts. However, there may be some normalization,
+    rewriting or other process that requires the audience to be set to a deployment-specific value.
+    See "Workload Identifiers and Authentication Granularity" in {{!I-D.ietf-wimse-workload-creds}}.
     * `exp`: The expiration time of the WPT (as defined in {{Section 4.1.4 of RFC7519}}). WPT lifetimes MUST be short,
      e.g., on the order of minutes or seconds.
     * `jti`: A unique identifier for the WPT. The value MUST be assigned such that there is a negligible probability that the same value will be assigned to any other WPT. Such uniqueness can be accomplished by encoding (base64url or any other suitable encoding) 128 bits of pseudorandom data.
@@ -361,7 +361,7 @@ IANA is requested to register the following entries to the "Hypertext Transfer P
 
 ## draft-ietf-wimse-wpt-02
 
-* Clarify WPT `aud` as HTTP target URI; note trusted local validation of audience.
+* Tie WPT `aud` to "Workload Identifiers and Authentication Granularity" in workload-creds.
 
 ## draft-ietf-wimse-wpt-01
 

--- a/draft-ietf-wimse-wpt.md
+++ b/draft-ietf-wimse-wpt.md
@@ -97,8 +97,9 @@ A WPT MUST contain the following:
      using the `application/wpt+jwt` media type.
 * in the JWT claims:
     * `aud`: The audience SHOULD contain the HTTP target URI ({{Section 7.1 of RFC9110}}) of the request
-     to which the WPT is attached, without query or fragment parts. However, there may be some normalization,
-    rewriting or other process that requires the audience to be set to a deployment-specific value.
+     to which the WPT is attached, without query or fragment parts. Senders set the audience to the URI they use for the request.
+     However, normalization, rewriting, or other deployment-specific processing may require a different audience value.
+     Recipients validate that the audience is intended for them, using trusted configuration or a local API (for example, to determine the expected request URI or to validate a received audience value); see "Workload Identifiers and Authentication Granularity" in {{!I-D.ietf-wimse-workload-creds}}.
     * `exp`: The expiration time of the WPT (as defined in {{Section 4.1.4 of RFC7519}}). WPT lifetimes MUST be short,
      e.g., on the order of minutes or seconds.
     * `jti`: A unique identifier for the WPT. The value MUST be assigned such that there is a negligible probability that the same value will be assigned to any other WPT. Such uniqueness can be accomplished by encoding (base64url or any other suitable encoding) 128 bits of pseudorandom data.
@@ -357,6 +358,10 @@ IANA is requested to register the following entries to the "Hypertext Transfer P
 
 # Document History
 <cref>RFC Editor: please remove before publication.</cref>
+
+## draft-ietf-wimse-wpt-02
+
+* Clarify WPT `aud` as HTTP target URI; note trusted local validation of audience.
 
 ## draft-ietf-wimse-wpt-01
 

--- a/draft-ietf-wimse-wpt.md
+++ b/draft-ietf-wimse-wpt.md
@@ -105,6 +105,7 @@ A WPT MUST contain the following:
     * `aud`: The audience SHOULD contain the HTTP target URI ({{Section 7.1 of RFC9110}}) of the request
      to which the WPT is attached, without query or fragment parts. However, there may be some normalization,
     rewriting or other process that requires the audience to be set to a deployment-specific value.
+    See "Application-Layer Audience" in {{!I-D.ietf-wimse-workload-creds}}.
     * `exp`: The expiration time of the WPT (as defined in {{Section 4.1.4 of RFC7519}}). WPT lifetimes MUST be short,
      e.g., on the order of minutes or seconds.
     * `jti`: A unique identifier for the WPT. The value MUST be assigned such that there is a negligible probability that the same value will be assigned to any other WPT. Such uniqueness can be accomplished by encoding (base64url or any other suitable encoding) 128 bits of pseudorandom data.
@@ -374,6 +375,10 @@ IANA is requested to register the following entry to the "Hypertext Transfer Pro
 
 # Document History
 <cref>RFC Editor: please remove before publication.</cref>
+
+## draft-ietf-wimse-wpt-04
+
+* Tie WPT `aud` to application-layer audience in workload-creds (#175).
 
 ## draft-ietf-wimse-wpt-03
 

--- a/draft-ietf-wimse-wpt.md
+++ b/draft-ietf-wimse-wpt.md
@@ -99,7 +99,7 @@ A WPT MUST contain the following:
     * `aud`: The audience SHOULD contain the HTTP target URI ({{Section 7.1 of RFC9110}}) of the request
      to which the WPT is attached, without query or fragment parts. However, there may be some normalization,
     rewriting or other process that requires the audience to be set to a deployment-specific value.
-    See "Workload Identifiers and Authentication Granularity" in {{!I-D.ietf-wimse-workload-creds}}.
+    See "Application-Layer Audience" in {{!I-D.ietf-wimse-workload-creds}}.
     * `exp`: The expiration time of the WPT (as defined in {{Section 4.1.4 of RFC7519}}). WPT lifetimes MUST be short,
      e.g., on the order of minutes or seconds.
     * `jti`: A unique identifier for the WPT. The value MUST be assigned such that there is a negligible probability that the same value will be assigned to any other WPT. Such uniqueness can be accomplished by encoding (base64url or any other suitable encoding) 128 bits of pseudorandom data.


### PR DESCRIPTION
- **workload-creds (#173, #175):** Replace the mandatory access-path-to-identifier mapping API with infrastructure support for verifying that an HTTP target URI (RFC 9110 Section 7.1, without query or fragment) is intended for a workload. Document the roles of HTTP target URI (audience) vs Workload Identifier (sender) for WPT, HTTP signatures, and mTLS.
- **WPT (#175):** Tie `aud` to "Workload Identifiers and Authentication Granularity" in workload-creds; otherwise unchanged from main.

Closes #173, #175. Addresses #240.