### PR TITLE
Clarify workload identifier and add security considerations

### DIFF
--- a/draft-ietf-wimse-workload-creds.md
+++ b/draft-ietf-wimse-workload-creds.md
@@ -436,9 +436,7 @@ When a deployment uses the `iss` claim for key distribution as described in {{wi
 
 A workload that validates its peer's credential against the trust anchors for a trust domain and then stops has learned only that its peer belongs to that trust domain. It has not learned which workload the peer is. {{granular-auth}} requires the comparison that closes this gap.
 
-Without that comparison, every workload in the trust domain looks the same. Any workload holding a valid credential can be accepted in place of any other, so an attacker who compromises one workload gains the access of all of them, even if the workload they compromised had little access of its own. A credential issued by mistake, or one belonging to a workload that no longer exists, can be used in the same way until it expires.
-
-Both sides of a call are affected. A client that does not check which workload it reached can be tricked into sending its requests, along with its own credential and proof of possession, to a workload the attacker controls in the same trust domain. A receiving application that only checks trust domain membership gives every workload in the domain the access it meant to give to one.
+Without that comparison, every workload in the trust domain looks the same. Any workload holding a valid credential can be accepted in place of any other, so an attacker who compromises one workload gains the access of all of them, even if the workload they compromised had little access of its own. A credential issued by mistake, or one belonging to a workload that no longer exists, can be used in the same way until it expires. This affects both sides of a call, workloads acting a clients and workloads acting as servers.
 
 Proof of possession does not help here. It shows that the peer holds the private key for the credential it presented ({{wit-pop}}). It does not show that this credential is the one the peer was supposed to present. The same is true when a Workload Identity Certificate is used at the transport layer.
 

--- a/draft-ietf-wimse-workload-creds.md
+++ b/draft-ietf-wimse-workload-creds.md
@@ -150,18 +150,24 @@ Depending on the protocol, the workload authentication may happen during step (2
 The Workload Identifier is a URI and its baseline syntax and processing requirements are defined in {{!WIMSE-ID=I-D.ietf-wimse-identifier}}.
 While deployments define how they assign identifiers and what the path portion means, implementations MUST enforce the URI requirements outlined in {{Section 4.1 of WIMSE-ID}}.
 
-A Workload Identifier is generally not a name that a client dials. Clients reach a workload through an external access name,
-such as a DNS name or a Kubernetes Service or Ingress host, while the authority component of a Workload Identifier is a
-trust domain rather than a resolvable host. Validating a peer's credential against the trust anchors of its trust domain
-({{trust-anchors}}) therefore establishes only that the peer holds a credential issued within that domain, not that it is
-the workload the client intended to reach.
+Prior to WIMSE, many containerized runtime platforms could not authenticate a peer as a specific workload;  
+they could only establish that the peer belonged to a given trust domain.
+With mutual TLS (mTLS), for example, there is often no reliable way to map the external access name a client uses to reach a workload
+(such as a Kubernetes Ingress path, service name, or HTTP Host header field)
+to the SubjectAltName in the presented certificate.
+As a result, the client can verify that the server certificate is valid within a trust domain,
+but not that it belongs to the particular workload the client intended to reach.
 
-To authenticate a specific peer, a client MUST compare the Workload Identifier in the presented credential against the
-identifier it expects for the workload it is calling; successful trust anchor validation alone MUST NOT be treated as
-authentication of that workload (see {{trust-domain-membership}} for security considerations). This requires a mapping from
-the external access name to the expected Workload Identifier, and agreement between the peers on the granularity of
-identifiers, for example one per service or one per running instance. This document does not define how that mapping is
-established or distributed.
+To enable mutual and granular authentication between workloads, two things must be in place:
+
+- Each workload must know its own identifier.
+- There needs to be an explicit mapping from the external access name used to access a workload (such as an Ingress path or service DNS name)
+to its Workload Identifier.
+
+Once these conditions are met, the methods described in this document can be used for the caller and callee to mutually authenticate.
+
+Implementations MUST allow for defining this mapping between the workload's external access name and the Workload Identifier (e.g., through
+callback functions). Deployments SHOULD use these features to establish a consistent set of identifiers within their environment.
 
 # Conventions and Definitions
 
@@ -566,7 +572,7 @@ IANA is requested to register the following entries to the "Hypertext Transfer P
 
 ## draft-ietf-wimse-workload-creds-03
 
-* Rework the Workload Identifiers and Authentication Granularity section and added a new Security Considerations subsection to describe the impact.
+* Added a section to describe the security considerations of granular authentication.
 * Editorial: consistent use of "proof of possession"/"PoP", with the abbreviation expanded on first use, and consistent capitalization of the defined term "Workload Identifier".
 
 ## draft-ietf-wimse-workload-creds-02

--- a/draft-ietf-wimse-workload-creds.md
+++ b/draft-ietf-wimse-workload-creds.md
@@ -150,24 +150,18 @@ Depending on the protocol, the workload authentication may happen during step (2
 The Workload Identifier is a URI and its baseline syntax and processing requirements are defined in {{!WIMSE-ID=I-D.ietf-wimse-identifier}}.
 While deployments define how they assign identifiers and what the path portion means, implementations MUST enforce the URI requirements outlined in {{Section 4.1 of WIMSE-ID}}.
 
-Prior to WIMSE, many containerized runtime platforms could not authenticate a peer as a specific workload;
-they could only establish that the peer belonged to a given trust domain.
-With mutual TLS (mTLS), for example, there is often no reliable way to map the external access name a client uses to reach a workload
-(such as a Kubernetes Ingress path, service name, or HTTP Host header field)
-to the SubjectAltName in the presented certificate.
-As a result, the client can verify that the server certificate is valid within a trust domain,
-but not that it belongs to the particular workload the client intended to reach.
+A Workload Identifier is generally not a name that a client dials. Clients reach a workload through an external access name,
+such as a DNS name or a Kubernetes Service or Ingress host, while the authority component of a Workload Identifier is a
+trust domain rather than a resolvable host. Validating a peer's credential against the trust anchors of its trust domain
+({{trust-anchors}}) therefore establishes only that the peer holds a credential issued within that domain, not that it is
+the workload the client intended to reach.
 
-To enable mutual and granular authentication between workloads, two things must be in place:
-
-- Each workload must know its own identifier.
-- There needs to be an explicit mapping from the external access name used to access a workload (such as an Ingress path or service DNS name)
-to its Workload Identifier.
-
-Once these conditions are met, the methods described in this document can be used for the caller and callee to mutually authenticate.
-
-Implementations MUST allow for defining this mapping between the workload's external access name and the Workload Identifier (e.g., through
-callback functions). Deployments SHOULD use these features to establish a consistent set of identifiers within their environment.
+To authenticate a specific peer, a client MUST compare the Workload Identifier in the presented credential against the
+identifier it expects for the workload it is calling; successful trust anchor validation alone MUST NOT be treated as
+authentication of that workload (see {{trust-domain-membership}} for security considerations). This requires a mapping from
+the external access name to the expected Workload Identifier, and agreement between the peers on the granularity of
+identifiers, for example one per service or one per running instance. This document does not define how that mapping is
+established or distributed.
 
 # Conventions and Definitions
 
@@ -432,6 +426,16 @@ Workload Identifiers ({{WIMSE-ID}}) are scoped to a trust domain (the URI author
 
 When a deployment uses the `iss` claim for key distribution as described in {{wit-iss-note}}, validators MUST enforce an allowlist of accepted issuers. Absent such a restriction, any entity could stand up an issuer, present a WIT with that issuer's `iss` value, and have it accepted by a validator that fetches and trusts the corresponding key material without verifying the issuer's legitimacy.
 
+## Trust Domain Membership and Peer Authentication {#trust-domain-membership}
+
+A workload that validates its peer's credential against the trust anchors for a trust domain and then stops has learned only that its peer belongs to that trust domain. It has not learned which workload the peer is. {{granular-auth}} requires the comparison that closes this gap.
+
+Without that comparison, every workload in the trust domain looks the same. Any workload holding a valid credential can be accepted in place of any other, so an attacker who compromises one workload gains the access of all of them, even if the workload they compromised had little access of its own. A credential issued by mistake, or one belonging to a workload that no longer exists, can be used in the same way until it expires.
+
+Both sides of a call are affected. A client that does not check which workload it reached can be tricked into sending its requests, along with its own credential and proof of possession, to a workload the attacker controls in the same trust domain. A receiving application that only checks trust domain membership gives every workload in the domain the access it meant to give to one.
+
+Proof of possession does not help here. It shows that the peer holds the private key for the credential it presented ({{wit-pop}}). It does not show that this credential is the one the peer was supposed to present. The same is true when a Workload Identity Certificate is used at the transport layer.
+
 ## Workload Identity Token and Proof of Possession {#wit-pop}
 
 The Workload Identity Token (WIT) is bound to a secret cryptographic key and is always presented with a proof of possession (PoP) as described in {{to-wit}}. The WIT is a general purpose token that can be presented in multiple contexts. The WIT and its PoP are only used in the application-layer options, and both are not used in mTLS. The WIT MUST NOT be used as a bearer token. While this helps reduce the sensitivity of the token it is still possible that a token and its PoP may be captured and replayed within the PoP's lifetime. The following are some mitigations for the capture and reuse of the WIT and its PoP:
@@ -562,6 +566,7 @@ IANA is requested to register the following entries to the "Hypertext Transfer P
 
 ## draft-ietf-wimse-workload-creds-03
 
+* Rework the Workload Identifiers and Authentication Granularity section and added a new Security Considerations subsection to describe the impact.
 * Editorial: consistent use of "proof of possession"/"PoP", with the abbreviation expanded on first use, and consistent capitalization of the defined term "Workload Identifier".
 
 ## draft-ietf-wimse-workload-creds-02

--- a/draft-ietf-wimse-workload-creds.md
+++ b/draft-ietf-wimse-workload-creds.md
@@ -150,7 +150,7 @@ Depending on the protocol, the workload authentication may happen during step (2
 The Workload Identifier is a URI and its baseline syntax and processing requirements are defined in {{!WIMSE-ID=I-D.ietf-wimse-identifier}}.
 While deployments define how they assign identifiers and what the path portion means, implementations MUST enforce the URI requirements outlined in {{Section 4.1 of WIMSE-ID}}.
 
-Prior to WIMSE, many containerized runtime platforms could not authenticate a peer as a specific workload;  
+Prior to WIMSE, many containerized runtime platforms could not authenticate a peer as a specific workload;
 they could only establish that the peer belonged to a given trust domain.
 With mutual TLS (mTLS), for example, there is often no reliable way to map the external access name a client uses to reach a workload
 (such as a Kubernetes Ingress path, service name, or HTTP Host header field)


### PR DESCRIPTION
Added security considerations for granular auth section.

Related to #272 