### PR TITLE
Shorten/clarify WIT validation

### DIFF
--- a/draft-ietf-wimse-workload-creds.md
+++ b/draft-ietf-wimse-workload-creds.md
@@ -351,7 +351,7 @@ Verification of a WIT follows {{RFC7515}} and the JWT best practices in {{I-D.ie
 * The `cnf` claim is present and contains a `jwk` object with an `alg` member as specified in {{to-wit}}.
 * Additional claims that are not understood are ignored, as specified in {{add-claims}}.
 
-WITs with an expiration time unreasonably far in the future SHOULD be rejected.
+See {{wit-lifetime}} for WIT lifetime considerations.
 
 ## Error Conditions
 
@@ -449,7 +449,7 @@ When a deployment uses the `iss` claim for key distribution as described in {{wi
 
 The Workload Identity Token (WIT) is bound to a secret cryptographic key and is always presented with a proof of possession (PoP) as described in {{to-wit}}. The WIT is a general purpose token that can be presented in multiple contexts. The WIT and its PoP are used for application-layer authentication; they are not used as the client or server credential for mutual TLS, which uses the Workload Identity Certificate ({{to-wic}}). The WIT MUST NOT be used as a bearer token. While this helps reduce the sensitivity of the token it is still possible that a token and its PoP may be captured and replayed within the PoP's lifetime. The following are some mitigations for the capture and reuse of the WIT and its PoP:
 
-### Limiting Workload Identity Token Lifespan
+### Limiting Workload Identity Token Lifespan {#wit-lifetime}
 
 The WIT MUST have a limited lifetime expressed through the `exp` claim. If both a WIT and its corresponding private key are compromised, an attacker can impersonate the workload until the WIT expires. Because JWT-based credentials such as the WIT are not generally revocable on demand, a short expiration is the primary mitigation against continued use of a compromised WIT and key. WITs SHOULD therefore be short-lived, typically on the order of hours, with the chosen lifetime balancing the operational cost of frequent refresh against the window of exposure if a credential is compromised.
 

--- a/draft-ietf-wimse-workload-creds.md
+++ b/draft-ietf-wimse-workload-creds.md
@@ -345,13 +345,13 @@ Implementations MAY include the `iss` claim in the form of a `https` URL to faci
 Verification of a WIT follows {{RFC7515}} and the JWT best practices in {{RFC8725}}, with the WIMSE-specific requirements below. To validate a WIT, the recipient MUST ensure the following:
 
 * The token is a single well-formed JWT using JWS compact serialization ({{RFC7515}}, {{RFC7519}}).
+* The `sub` claim is present and is a single Workload Identifier ({{WIMSE-ID}}, {{single-workload-identity}}). The recipient uses the trust domain of that identifier to select the configured trust anchors ({{trust-anchors}}).
 * The `typ` JOSE header parameter conveys a media type of `wit+jwt`.
-* The `alg` JOSE header parameter identifies an asymmetric digital signature algorithm that is acceptable per the trust domain's policy; the value `none` MUST NOT be accepted. Algorithms used with symmetric keys and encryption algorithms MUST NOT be accepted.
-* The signature is valid using key material from the trust anchors configured for the trust domain in the `sub` claim, as described in {{trust-anchors}}. If the JWS header contains a `kid` parameter, the recipient MUST use the configured key with that `kid` value. If `kid` is absent, key selection MUST follow the deployment policy in {{trust-anchors}}.
-* The `sub` claim is present and is a single Workload Identifier ({{WIMSE-ID}}, {{single-workload-identity}}) whose trust domain matches the trust anchors used.
-* The `exp` claim is present and conveys a time that has not passed. WITs with an expiration time unreasonably far in the future SHOULD be rejected.
+* The JWS signature is valid under those trust anchors, as described in {{trust-anchors}}.
 * The `cnf` claim is present and contains a `jwk` object with an `alg` member as specified in {{to-wit}}.
 * Additional claims that are not understood are ignored, as specified in {{add-claims}}.
+
+WITs with an expiration time unreasonably far in the future SHOULD be rejected.
 
 ## Error Conditions
 
@@ -575,7 +575,7 @@ IANA is requested to register the following entries to the "Hypertext Transfer P
 
 ## draft-ietf-wimse-workload-creds-03
 
-* Add a WIT validation procedure for recipients (#290).
+* Add a WIT validation procedure for recipients (#290, #294).
 * Clarify that WIT/PoP are application-layer credentials and are not used for mutual TLS; TLS binding does not change that (#256).
 * Clarify that the one-Workload-Identifier-per-credential rule restricts only Workload Identifiers, not other identifiers in the credential.
 * State the WIC revocation stance: short lifetimes like WITs; no CRL reliance (#270).

--- a/draft-ietf-wimse-workload-creds.md
+++ b/draft-ietf-wimse-workload-creds.md
@@ -51,7 +51,7 @@ normative:
   RFC7518:
   RFC7519:
   RFC7800:
-  RFC8725:
+  I-D.ietf-oauth-rfc8725bis:
   RFC9110:
 
 informative:
@@ -207,7 +207,7 @@ A WIT MUST contain the following content, except where noted:
 * in the JOSE header:
     * `alg`: An identifier for a JWS asymmetric digital signature algorithm
      (registered algorithm identifiers are listed in the IANA JOSE Algorithms registry {{IANA.JOSE.ALGS}}). The value `none` MUST NOT be used.
-    * `typ`: the WIT is explicitly typed, as recommended in {{Section 3.11 of RFC8725}}, using the `wit+jwt` media type.
+    * `typ`: the WIT is explicitly typed, as recommended in {{Section 3.11 of I-D.ietf-oauth-rfc8725bis}}, using the `wit+jwt` media type.
 * in the JWT claims:
     * `iss`: The issuer of the token, which is the Identity Server, represented by a URI. The `iss` claim is RECOMMENDED but optional; when present, it is particularly useful for auditing and operations (for example, identifying which Identity Server issued the WIT in logs or compliance records). See {{wit-iss-note}} for key distribution and validation context.
     * `sub`: The subject of the token, which is the single Workload Identifier for the workload used for authentication and authorization, as defined in {{WIMSE-ID}} and {{single-workload-identity}}. {{granular-auth}} provides additional requirements associated with these identifiers, so they can be used to secure workload-to-workload communication.
@@ -342,7 +342,7 @@ Implementations MAY include the `iss` claim in the form of a `https` URL to faci
 
 ### Validating the WIT {#wit-validation}
 
-Verification of a WIT follows {{RFC7515}} and the JWT best practices in {{RFC8725}}, with the WIMSE-specific requirements below. To validate a WIT, the recipient MUST ensure the following:
+Verification of a WIT follows {{RFC7515}} and the JWT best practices in {{I-D.ietf-oauth-rfc8725bis}}, with the WIMSE-specific requirements below. To validate a WIT, the recipient MUST ensure the following:
 
 * The token is a single well-formed JWT using JWS compact serialization ({{RFC7515}}, {{RFC7519}}).
 * The `sub` claim is present and is a single Workload Identifier ({{WIMSE-ID}}, {{single-workload-identity}}). The recipient uses the trust domain of that identifier to select the configured trust anchors ({{trust-anchors}}).


### PR DESCRIPTION
## Summary
- Reorder WIT validation so `sub` selects trust anchors before signature checks.
- Rely on RFC 7515 and draft-ietf-oauth-rfc8725bis for generic JWT rules; list only WIMSE-specific MUST requirements.
- Keep the long-lifetime rejection as a separate SHOULD after the list.

Fixes #294

Made with [Cursor](https://cursor.com)