### PR TITLE
Add an implementation status entry for wimsey

### DIFF
--- a/draft-ietf-wimse-http-signature.md
+++ b/draft-ietf-wimse-http-signature.md
@@ -283,24 +283,11 @@ According to RFC 7942, "this will allow reviewers and working groups to assign d
 * Organization: independent
 * Implementation: <https://github.com/kanywst/wimsey>
 * Maturity:
-    * WIT + HTTP Message Signatures: alpha, not for production
-* Coverage: The Section 3 profile for both requests and responses, against
-  `draft-ietf-wimse-http-signature-06`. Requests: the mandatory covered
-  components, `created`/`expires`/`nonce`/`tag`, `wimse-aud`, and rejection of
-  the forbidden `keyid` and `alg` parameters. Responses: `@status`, the `;req`
-  covered components, `wimse-req-nonce`, and a response profile in which
-  `wimse-aud` is forbidden. Signing is `EdDSA` or `ES256`. Replay detection is
-  left to the caller: the implementation checks that a `nonce` is present but
-  does not remember the ones it has seen.
+    * WIT + HTTP Message Signatures: alpha
+* Coverage: WIT, HTTP Message Signatures, signed responses
 * License: Apache 2.0
 * Contact: [kanywst on GitHub](https://github.com/kanywst)
 * Last updated: 27-Aug-2026
-* Notes: Publishes cross-implementation test vectors in which every negative
-  case names the reason the input must be rejected, so an input turned away
-  for the wrong reason counts as a failure:
-  <https://github.com/kanywst/wimsey/tree/main/conformance>. Two independent
-  implementations have run them and reported results on the working group
-  list.
 
 # Security Considerations
 

--- a/draft-ietf-wimse-http-signature.md
+++ b/draft-ietf-wimse-http-signature.md
@@ -278,6 +278,30 @@ According to RFC 7942, "this will allow reviewers and working groups to assign d
 * Contact: jason@cofide.io
 * Last updated: 13-Nov-2025
 
+## wimsey
+
+* Organization: independent
+* Implementation: <https://github.com/kanywst/wimsey>
+* Maturity:
+    * WIT + HTTP Message Signatures: alpha, not for production
+* Coverage: The Section 3 profile for both requests and responses, against
+  `draft-ietf-wimse-http-signature-06`. Requests: the mandatory covered
+  components, `created`/`expires`/`nonce`/`tag`, `wimse-aud`, and rejection of
+  the forbidden `keyid` and `alg` parameters. Responses: `@status`, the `;req`
+  covered components, `wimse-req-nonce`, and a response profile in which
+  `wimse-aud` is forbidden. Signing is `EdDSA` or `ES256`. Replay detection is
+  left to the caller: the implementation checks that a `nonce` is present but
+  does not remember the ones it has seen.
+* License: Apache 2.0
+* Contact: [kanywst on GitHub](https://github.com/kanywst)
+* Last updated: 27-Aug-2026
+* Notes: Publishes cross-implementation test vectors in which every negative
+  case names the reason the input must be rejected, so an input turned away
+  for the wrong reason counts as a failure:
+  <https://github.com/kanywst/wimsey/tree/main/conformance>. Two independent
+  implementations have run them and reported results on the working group
+  list.
+
 # Security Considerations
 
 This section includes security considerations that are specific to the HTTP Signature protocol defined here. Refer to

--- a/draft-ietf-wimse-workload-creds.md
+++ b/draft-ietf-wimse-workload-creds.md
@@ -441,21 +441,10 @@ wimsey
 * Organization: independent
 * Implementation: <https://github.com/kanywst/wimsey>
 * Maturity:
-    * Workload Identity Token: alpha, not for production
-    * Workload Identity Certificate: alpha, not for production
-* Coverage: WIT issuance and verification against
-  `draft-ietf-wimse-workload-creds-02`, with the mandatory `sub`, `exp` and
-  `cnf` claims, the optional `iss`, `iat` and `jti`, and the `alg` member
-  inside the `cnf` JWK, which is enforced as the algorithm the proof of
-  possession must use. Both `EdDSA` and `ES256`, in any combination: an EdDSA
-  issuer with an ES256 confirmation key is exercised by a test vector.
-  Workload Identity Certificate issuance and verification with the identifier
-  in a URI SAN; certificates are Ed25519 only, since the mutual-TLS document
-  carries no equivalent of Section 5.1.
-* License: Apache 2.0
+    * Workload Identity Token: alpha
+    * Workload Identity Certificate: alpha
+* Coverage: WIT, Workload Identity Certificate
 * Contact: [kanywst on GitHub](https://github.com/kanywst)
-* Last updated: 27-Aug-2026
-
 
 # Security Considerations
 

--- a/draft-ietf-wimse-workload-creds.md
+++ b/draft-ietf-wimse-workload-creds.md
@@ -436,6 +436,26 @@ Teleport - Machine & Workload Identity
 * Coverage: Workload Identity Certificate
 * Contact: noah@goteleport.com
 
+wimsey
+
+* Organization: independent
+* Implementation: <https://github.com/kanywst/wimsey>
+* Maturity:
+    * Workload Identity Token: alpha, not for production
+    * Workload Identity Certificate: alpha, not for production
+* Coverage: WIT issuance and verification against
+  `draft-ietf-wimse-workload-creds-02`, with the mandatory `sub`, `exp` and
+  `cnf` claims, the optional `iss`, `iat` and `jti`, and the `alg` member
+  inside the `cnf` JWK, which is enforced as the algorithm the proof of
+  possession must use. Both `EdDSA` and `ES256`, in any combination: an EdDSA
+  issuer with an ES256 confirmation key is exercised by a test vector.
+  Workload Identity Certificate issuance and verification with the identifier
+  in a URI SAN; certificates are Ed25519 only, since the mutual-TLS document
+  carries no equivalent of Section 5.1.
+* License: Apache 2.0
+* Contact: [kanywst on GitHub](https://github.com/kanywst)
+* Last updated: 27-Aug-2026
+
 
 # Security Considerations
 


### PR DESCRIPTION
An entry for `wimsey`, a Rust implementation of these documents, per Yaron's invitation on the list: <https://github.com/kanywst/wimsey>.

The WPT and mutual-TLS documents have no Implementation Status section. `wimsey` implements both — happy to add the RFC 7942 boilerplate and an entry to each if you want it.

`Contact:` is a GitHub link rather than an email, following the SPIFFE entry. Both documents build locally.